### PR TITLE
SDI-1539: TimeDB friendly cassandra metrics

### DIFF
--- a/cassandra/utils.go
+++ b/cassandra/utils.go
@@ -154,7 +154,7 @@ func makeLitteralNamespace(url, name string) []string {
 	return ns
 }
 
-// makeDynamicNamespace returns a dynamic namespace
+// makeDynamicNamespace returns a dynamic namespace for metric types
 func makeDynamicNamespace(host, url, name string) core.Namespace {
 	ns := core.NewNamespace("intel", "cassandra", "node").AddDynamicElement("nodeName", "The name of a Cassandra node")
 

--- a/examples/tasks/cassandra-influx-task.json
+++ b/examples/tasks/cassandra-influx-task.json
@@ -1,0 +1,48 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/cassandra/node/*/org_apache_cassandra_metrics/type/*/keyspace/*/name/*/Value":{},
+                "/intel/cassandra/node/*/org_apache_cassandra_metrics/type/*/keyspace/*/scope/*/name/*/Max":{}, 
+                "/intel/cassandra/node/*/org_apache_cassandra_metrics/type/*/keyspace/*/scope/*/name/*/50thPercentile": {}
+            },
+            "config": {
+                "/intel/cassandra": {
+                    "url": "192.168.99.100",
+                    "port": 8082
+                }
+            },
+            "process": [
+                {
+                    "plugin_name": "passthru",
+                    "process": null,
+                    "publish": [
+                        {                         
+                            "plugin_name": "file",
+                            "config": {
+                                "file": "/tmp/collected_cassandra"
+                            }
+                        },
+                        {
+                            "plugin_name": "influx",                            
+                            "config": {
+                                "host": "192.168.99.100",
+                                "port": 8086,
+                                "database": "snap",
+                                "user": "admin",
+                                "password": "admin"
+                            }
+                        }
+                    ],
+                    "config": null
+                }
+            ],
+            "publish": null
+        }
+    }
+}


### PR DESCRIPTION
### Summary
* Enhanced the metrics with TimeDB friendly tags and namespaces.

### Test Done
* Unit tests
* Integration tests
* Tested with InfluxDB and Grafana

![screen shot 2016-06-29 at 11 05 42 am](https://cloud.githubusercontent.com/assets/13841563/16467131/d2456210-3dfa-11e6-81ea-de6923007532.png)

